### PR TITLE
Fix three critical code bugs

### DIFF
--- a/framebuffer.c
+++ b/framebuffer.c
@@ -121,11 +121,13 @@ void fb_cleanScreen()
 
 void draw_pixel(int x, int y, unsigned char attr)
 {
+    if (x < 0 || y < 0) return;
+    if ((unsigned int)x >= width || (unsigned int)y >= height) return;
     int offs = (y * pitch) + (x * 4);
     *((unsigned int *)(fb + offs)) = vgapal[attr & 0x0f];
 }
 
-void draw_pect(int x1, int y1, int x2, int y2, unsigned char attr, int fill)
+void draw_rect(int x1, int y1, int x2, int y2, unsigned char attr, int fill)
 {
     int y = y1;
 

--- a/framebuffer.c
+++ b/framebuffer.c
@@ -121,8 +121,10 @@ void fb_cleanScreen()
 
 void draw_pixel(int x, int y, unsigned char attr)
 {
-    if (x < 0 || y < 0) return;
-    if ((unsigned int)x >= width || (unsigned int)y >= height) return;
+    if (x < 0 || y < 0)
+        return;
+    if ((unsigned int)x >= width || (unsigned int)y >= height)
+        return;
     int offs = (y * pitch) + (x * 4);
     *((unsigned int *)(fb + offs)) = vgapal[attr & 0x0f];
 }

--- a/print.c
+++ b/print.c
@@ -92,13 +92,17 @@ uint32_t printk(const char *format, ...)
             switch (format[++i])
             {
             case 'x':
-                integer = va_arg(args, int64_t);
-                buffer_size += hex_to_string(buffer, buffer_size, (uint64_t)integer);
+                {
+                    uint64_t uinteger = va_arg(args, uint64_t);
+                    buffer_size += hex_to_string(buffer, buffer_size, uinteger);
+                }
                 break;
 
             case 'u':
-                integer = va_arg(args, int64_t);
-                buffer_size += udecimal_to_string(buffer, buffer_size, (uint64_t)integer);
+                {
+                    uint64_t uinteger = va_arg(args, uint64_t);
+                    buffer_size += udecimal_to_string(buffer, buffer_size, uinteger);
+                }
                 break;
 
             case 'd':

--- a/print.c
+++ b/print.c
@@ -92,18 +92,18 @@ uint32_t printk(const char *format, ...)
             switch (format[++i])
             {
             case 'x':
-                {
-                    uint64_t uinteger = va_arg(args, uint64_t);
-                    buffer_size += hex_to_string(buffer, buffer_size, uinteger);
-                }
-                break;
+            {
+                uint64_t uinteger = va_arg(args, uint64_t);
+                buffer_size += hex_to_string(buffer, buffer_size, uinteger);
+            }
+            break;
 
             case 'u':
-                {
-                    uint64_t uinteger = va_arg(args, uint64_t);
-                    buffer_size += udecimal_to_string(buffer, buffer_size, uinteger);
-                }
-                break;
+            {
+                uint64_t uinteger = va_arg(args, uint64_t);
+                buffer_size += udecimal_to_string(buffer, buffer_size, uinteger);
+            }
+            break;
 
             case 'd':
                 integer = va_arg(args, int64_t);

--- a/rand.c
+++ b/rand.c
@@ -23,11 +23,22 @@ void init_rand()
  */
 uint32_t rand(uint32_t min, uint32_t max)
 {
+    if (min == max)
+    {
+        return min;
+    }
+    if (min > max)
+    {
+        uint32_t tmp = min;
+        min = max;
+        max = tmp;
+    }
     // may need to wait for entropy: bits 24-31 store how many words are
     // available for reading; require at least one
     while (!((*RNG_STATUS) >> 24))
     {
         asm volatile("nop");
     }
-    return *RNG_DATA % (max - min) + min;
+    uint32_t range = (max - min) + 1U; // inclusive upper bound
+    return (uint32_t)(*RNG_DATA % range) + min;
 }


### PR DESCRIPTION
Fix framebuffer out-of-bounds writes and API mismatch, correct `printk` varargs for unsigned types, and harden `rand` function range logic.

The framebuffer's `draw_pixel` lacked bounds checks, risking memory corruption. `draw_pect` was also misnamed, causing an API mismatch. `printk` used `int64_t` for `%u` and `%x`, leading to undefined behavior for 64-bit unsigned values. The `rand` function had an exclusive upper bound and didn't handle `min >= max` edge cases, potentially causing division by zero or incorrect ranges.

---
<a href="https://cursor.com/background-agent?bcId=bc-12eb5268-749f-450a-9ba3-d93b180c7e09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-12eb5268-749f-450a-9ba3-d93b180c7e09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

